### PR TITLE
Fix background tiling on large screens

### DIFF
--- a/jot/css/main.css
+++ b/jot/css/main.css
@@ -12,24 +12,23 @@
   font-style: normal;
 }
 
-html { 
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-  background-repeat: no-repeat;
-  background-position: center center;
+html {
   -webkit-font-smoothing: antialiased !important;
 }
 
 body {
+	-webkit-background-size: cover;
+	-moz-background-size: cover;
+	-o-background-size: cover;
+	background-size: cover;
+	background-repeat: no-repeat;
+	background-position: center center;
 	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
 	margin: 12px;
 	border: 12px solid #fff;
-
 }
 
 .fontello {


### PR DESCRIPTION
Fixes #7

Another to do this would be to leave the CSS alone and use [`document.documentElement`](https://developer.mozilla.org/en-US/docs/Web/API/document.documentElement) instead of `document.body` in the Javascript. Feel free to reject the PR if you prefer that! I won't be offended. :smile: 
